### PR TITLE
Remove Timezone Support release note from v4.18.0

### DIFF
--- a/integration-gateway-platform-reference/integration-gateway-release-notes.md
+++ b/integration-gateway-platform-reference/integration-gateway-release-notes.md
@@ -9,7 +9,6 @@ This page tracks features, bug fixes, and other improvements included in each In
 * **Git Adapter**: Introduces a new Git adapter
 * **BuildHelper: Fiserv Optis**: Adds BuildHelper support for Fiserv Optis
 * **Join Node (ETL)**: Adds a new JOIN node to the workflow builder, which enables more complex workflows
-* **Timezone Support**: Adds timezone support to the integration scheduler
 * **Integration Version Manager**: Provides a new version deployment mechanism for integrations and integration components
 * **SymXchange Adapter**: Supports the new "versionless" URL scheme
 * **Autocomplete**: Improves tab completion


### PR DESCRIPTION
## Summary
- Removes the **Timezone Support** bullet from the v4.18.0 New Features section in the Integration Gateway release notes
- This feature is pushed to the next release

## Test plan
- [ ] Verify the Timezone Support line is no longer present in the v4.18.0 release notes
- [ ] Verify no other content was changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)