### PR TITLE
Add v4.19.0 release docs and MCP tool updates

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -63,6 +63,8 @@
   * [Integration Gateway SAML Config Reference](how-to-guides/how-to-set-up-single-sign-on-sso/integration-gateway-saml-config-reference.md)
 * [How to Install the Integration Gateway App for Zoom Contact Center](how-to-guides/how-to-install-the-integration-gateway-app-for-zoom-contact-center.md)
 * [How to use the Vault](how-to-guides/how-to-use-the-vault.md)
+* [How to Review Field Mappings with Quick Mapping](how-to-guides/how-to-review-field-mappings-with-quick-mapping.md)
+* [How to Track Mapping Progress](how-to-guides/how-to-track-mapping-progress.md)
 
 ## Reference
 

--- a/how-to-guides/how-to-review-field-mappings-with-quick-mapping.md
+++ b/how-to-guides/how-to-review-field-mappings-with-quick-mapping.md
@@ -1,0 +1,43 @@
+# How to Review Field Mappings with Quick Mapping
+
+Quick Mapping lets you review a service request's unmapped fields one at a time through a card-based interface. Mark each field as approved, not used, or change requested — no need to scroll through the full table.
+
+Quick Mapping automatically skips fields already marked as Approved, Not Used, or Change Requested. It only shows fields that still need attention.
+
+## Quick Mapping Workflow
+
+To review unmapped fields for a service request:
+
+1. Click **Mapping** and select an integration from the drop-down menu.
+2. Select the service request you want to review.
+3. Click **Quick Mapping** above the field mapping table.
+4. For each field, decide if you need to map the field:
+   - **Yes** — Continue to the value check. See [Approve or Request a Change](#approve-or-request-a-change).
+   - **No** — The system marks the field as Not Used and displays the next field.
+   - **Save for later** — Skip the field. Its status does not change.
+5. After you review all fields, the system displays a summary of the number of fields saved and skipped.
+
+## Approve or Request a Change
+
+When you mark a field as needed, the card displays its current value and source information.
+
+1. Review the current value on the card.
+2. Choose an action:
+   - Click **Yes** if the value is correct. The system marks the field as Approved.
+   - Click **No** to describe a required change.
+3. If you clicked **No**, enter a description of the correct value or source in the text area.
+4. Click **Save & Continue**. The system posts a comment on the field and sets the status to Change Requested.
+
+## Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| **← / →** | Highlight Yes or No. Press the same arrow again to confirm. |
+| **Enter** | Confirm the highlighted choice |
+| **S** | Skip the current field |
+| **Escape** | Close the dialog |
+
+## How It Works
+
+- Skipped fields remain in their original state and appear again the next time you start Quick Mapping for the same service request.
+- Progress updates immediately in the service request's completion percentage and the overall integration progress bar.

--- a/how-to-guides/how-to-track-mapping-progress.md
+++ b/how-to-guides/how-to-track-mapping-progress.md
@@ -1,0 +1,47 @@
+# How to Track Mapping Progress
+
+The Mapping Progress tab on the Dashboard displays field mapping completion across service requests, with forecast data, target dates, and status breakdowns for an integration.
+
+## Mapping Progress Workflow
+
+To review mapping progress for an integration:
+
+1. Click **Dashboard** and select the **Mapping Progress** tab.
+2. Choose an integration from the drop-down menu. If you set a default integration, it loads automatically.
+3. Review the dashboard components:
+   - **Overall progress bar** — Percentage of fields in a done status across all service requests, with a count of unresolved comments.
+   - **Forecast cards** — Four stat cards that summarize the project trajectory. See [Configure Forecast Settings](#configure-forecast-settings).
+   - **Pie chart** — Fields broken down by status category (Done, In Progress, Unstarted, and No Status).
+   - **Service request list** — Each service request with its own progress bar and completion percentage. Click the arrow button next to a service request name to open its field mappings on the Mapping page.
+
+## Configure Forecast Settings
+
+The four forecast cards display these metrics:
+
+- **Project Status** — Whether the integration is on track, ahead of schedule, behind schedule, or past due. The system calculates this from the target date and the configured fields-per-day rate. If you do not set a target date, the status displays as "In Progress."
+- **Target Date** — The date the integration should reach completion. If the project is behind schedule, a "Need X/day" indicator shows the daily throughput required to finish on time.
+- **Fields / Day** — The configured daily mapping rate used for forecast calculations.
+- **Fields Left** — How many fields remain out of the total.
+
+Users with admin or staff permissions can configure the target date. To set a target date:
+
+1. Click the pencil icon on the **Target Date** card.
+2. Select a target date from the date picker.
+3. Click the check icon or click away to save.
+
+To set the daily mapping rate:
+
+1. Click the pencil icon on the **Fields / Day** card.
+2. Enter the expected daily mapping throughput.
+3. Click away to save.
+
+The Project Status card updates immediately to reflect whether the current rate meets the target.
+
+## Set a Default Integration
+
+To set a default integration that loads automatically when you open the Mapping Progress tab:
+
+1. Select the integration from the drop-down menu.
+2. Click **Set as default** below the drop-down menu.
+
+The star icon fills in to confirm. The default persists across sessions. To change the default, select a different integration and click **Set as default** again.

--- a/integration-gateway-platform-reference/integration-gateway-release-notes.md
+++ b/integration-gateway-platform-reference/integration-gateway-release-notes.md
@@ -2,9 +2,33 @@
 
 This page tracks features, bug fixes, and other improvements included in each Integration Gateway release.
 
-## v4.18.0 — March 17th, 2026
+## v4.19.0 — May 2026
 
 ### New Features
+
+* **Custom Adapters**: Build and deploy user-defined Python adapters with custom configuration schemas and file field support
+* **Mapping Progress Dashboard**: Track field mapping completion across service requests with forecast data, target dates, and status breakdowns
+* **Quick Mapping**: Review unmapped fields one at a time through a card-based interface with keyboard shortcuts
+* **Salesforce Bulk API v2.0**: Adds Bulk API 2.0 support to the Salesforce adapter
+* **Equifax Adapter**: Introduces a new Equifax adapter with multi-scope support
+* **Fiserv Optis Adapter**: Introduces a new Fiserv Optis adapter
+* **Join Node (ETL)**: Adds a new JOIN node to the ETL workflow builder
+
+### MCP
+
+* Adds MCP tools for building and managing custom adapters (`custom_adapter_code`, `custom_adapter_config`)
+
+### Improvements
+
+* **CMC Adapter Auth Type 3**: Extends the CMC adapter to support authentication type 3
+* **BuildHelper: Salesforce Bulk API v2.0**: Adds BuildHelper metadata for Salesforce Bulk API v2.0
+* **BuildHelper: jXchange ReST**: Adds BuildHelper metadata for Jack Henry jXchange ReST services
+* **BuildHelper: SymXchange**: Adds BuildHelper metadata for Jack Henry Symitar SymXchange
+* Adds descriptive error messages for adapter configurator permissions
+
+<details>
+
+<summary>v4.18.0 — March 17th, 2026</summary>
 
 * **Git Adapter**: Introduces a new Git adapter
 * **BuildHelper: Fiserv Optis**: Adds BuildHelper support for Fiserv Optis
@@ -13,9 +37,6 @@ This page tracks features, bug fixes, and other improvements included in each In
 * **SymXchange Adapter**: Supports the new "versionless" URL scheme
 * **Autocomplete**: Improves tab completion
 * **AI Code Completion**: Switches the build page backend from OpenAI to Anthropic
-
-### MCP
-
 * Adds a new MCP tool to directly reference BuildHelper adapter metadata
 * Adds a new MCP tool for run history search
 * Adds a new MCP tool to create and edit Frontends
@@ -24,23 +45,16 @@ This page tracks features, bug fixes, and other improvements included in each In
 * MCP admin page can now auto-generate a Claude-compatible configuration
 * Optimizes the MCP Run History tool for reduced context window usage
 * Optimizes the MCP build page read tool for reduced context window usage
-
-### Performance
-
 * Improves dashboard page performance
 * Improves log page performance
 * Improves run history redaction job performance
-
-### Improvements
-
 * BuildHelper button on the build page loads immediately on page load
 * Improves error messages when configuring schedules with insufficient permissions
 * `add_run_label` now ignores empty labels rather than throwing an exception
-
-### Fixes
-
 * MCP integration search now works with service requests and field mappings
 * Multiple performance, visibility, and usability enhancements
+
+</details>
 
 <details>
 

--- a/integration-gateway-platform-reference/mcp-server/tools-reference.md
+++ b/integration-gateway-platform-reference/mcp-server/tools-reference.md
@@ -16,6 +16,8 @@
 | [`query_buildhelper`](#query_buildhelper) | Query integration build assistance | Yes |
 | [`frontend_operations`](#frontend_operations) | Build and manage frontends | No |
 | [`django_admin`](#django_admin) | Manage Integration Gateway admin models | No |
+| [`custom_adapter_code`](#custom_adapter_code) | Build and manage custom adapters | No |
+| [`custom_adapter_config`](#custom_adapter_config) | Create and manage custom adapter configs | No |
 
 ---
 
@@ -201,6 +203,61 @@ Manages Django admin-registered models in Integration Gateway. Use this tool to 
 - The system masks encrypted fields in output
 - The system blocks certain models (for example, GlobalConfig) from access
 - The system caps results at 200 instances per query
+
+---
+
+### custom_adapter_code
+
+> Requires the **can_use_custom_adapters** account permission.
+
+Manages custom adapter code definitions. Custom adapters are user-defined Python classes that inherit from `BaseAdapter`. Each adapter defines a configuration schema specifying the fields its instances accept.
+
+**Actions:**
+
+- `list`: List all adapters. Code is omitted by default; set `include_code` to `true` to include it
+- `get`: Retrieve a single adapter by ID. Includes code by default
+- `create`: Create an adapter. Requires `name` and `code`; optionally accepts `description` and `config_schema`
+- `update`: Update an adapter. Requires `id` plus at least one of `name`, `description`, `code`, or `config_schema`
+- `delete`: Delete an adapter by ID. Cascade-deletes all associated configs
+- `deletion_impact`: Report how many configs the system would cascade-delete
+- `schema_change_impact`: Report warnings for a proposed schema change (added fields, type changes)
+
+**Returns:** Adapter object (ID, name, system, description, config_schema, timestamps, and optionally code) for get/create/update. Count and array for list. Impact details for the impact actions. Success confirmation for delete.
+
+**Behavior:**
+
+- Adapter code must define a `CustomAdapter` class inheriting from `BaseAdapter` with an `execute(self, request)` method. The `validate_config(self)` method is optional
+- Pre-loaded imports: `BaseAdapter`, `AdapterRequest`, `AdapterResponse`, `AdapterFlowController`, `MessageTypes`, `base64`
+- Access config values through `self.config`; file fields are base64 strings and must be decoded before use
+- Schema field types must be one of: `string`, `integer`, `float`, `boolean`, `array`, `object`, `encrypted_string`, `file`
+- Removing schema fields also removes them from all existing configs
+
+---
+
+### custom_adapter_config
+
+> Requires the **can_use_custom_adapters** account permission.
+
+Manages configurations for a custom adapter. Each config stores values matching the parent adapter's schema and represents a specific instance the adapter can run with.
+
+**Actions:**
+
+- `list`: List all configs for an adapter. Requires `code_id`
+- `get`: Retrieve a single config. Requires `code_id` and `config_id`
+- `create`: Create a config. Requires `code_id` and `name`; optionally accepts `active` (defaults to true) and `config_values`
+- `update`: Update a config. Requires `code_id` and `config_id` plus at least one of `name`, `active`, or `config_values`
+- `delete`: Delete a config. Requires `code_id` and `config_id`
+- `validate`: Run validation on all active, validation-enabled configs for the adapter and return results
+- `validation_result`: Return results from the most recent validation run without re-running
+
+**Returns:** Config object (ID, name, active, config_values) for get/create/update. Count and array for list. Results array (config_id, config_name, success, message, timestamp) for validate/validation_result. Success confirmation for delete.
+
+**Behavior:**
+
+- The system coerces values to schema types automatically
+- File fields accept base64 strings up to 1 MB decoded
+- The system masks encrypted and file fields in responses; they cannot be read back
+- Omit encrypted and file fields on update to preserve existing values
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds v4.19.0 release notes (Custom Adapters, Mapping Progress Dashboard, Quick Mapping, Salesforce Bulk API v2.0, Equifax Adapter, Fiserv Optis Adapter, JOIN Node ETL, MCP custom adapter tools, BuildHelper metadata updates, adapter configurator permissions error message)
- Adds two new how-to guides: Quick Mapping and Mapping Progress
- Adds `custom_adapter_code` and `custom_adapter_config` entries to MCP Tools Reference
- Updates SUMMARY.md navigation

## Test plan
- [ ] Verify release notes render correctly in GitBook preview
- [ ] Confirm Quick Mapping doc links and keyboard shortcut table render
- [ ] Confirm Mapping Progress doc structure and anchor links work
- [ ] Verify MCP Tools Reference table rows and new tool sections display correctly
- [ ] Check all internal anchor links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)