### PR TITLE
4.20 Release: docs updates

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -65,6 +65,7 @@
 * [How to use the Vault](how-to-guides/how-to-use-the-vault.md)
 * [How to Review Field Mappings with Quick Mapping](how-to-guides/how-to-review-field-mappings-with-quick-mapping.md)
 * [How to Track Mapping Progress](how-to-guides/how-to-track-mapping-progress.md)
+* [How to Configure Integration Retry](how-to-guides/how-to-configure-integration-retry.md)
 
 ## Reference
 

--- a/how-to-guides/how-to-configure-integration-retry.md
+++ b/how-to-guides/how-to-configure-integration-retry.md
@@ -1,0 +1,65 @@
+# How to Configure Integration Retry
+
+Integration Retry enables automatic retry logic for failed integrations. When an integration run fails, the system can automatically retry the execution based on a configurable schedule, which reduces the need for manual intervention in cases of transient failures.
+
+## Prerequisites
+
+- Admin or staff permissions on the Integration Gateway instance.
+- An existing integration with an Integration Config record.
+
+## Configure Retry Settings
+
+1. Navigate to **Build**.
+2. Right-click the integration you want to configure and select **Configure**.
+3. In the Configure Integration dialog, expand the **Retry Settings** panel.
+4. Select a **Retry Mode**:
+   - **None** — No retries (default).
+   - **Fixed Interval** — Retries at a constant delay between each attempt.
+   - **Exponential Backoff** — Retries with increasing delays. Each subsequent retry waits longer than the previous one.
+5. Set the **Initial Retry Delay (seconds)** — the base wait time before the first retry. For Fixed Interval, this is the delay between every attempt. For Exponential Backoff, this value doubles with each subsequent attempt.
+6. Set the **Retry Delay Jitter (seconds)** — a random value between 0 and this number is added to each delay. Jitter prevents multiple failing integrations from retrying at the same time.
+7. Set the **Retry Count** — the maximum number of retry attempts before the integration is marked as failed.
+8. Click **Save**.
+
+## Field Reference
+
+| Field | Type | Default | Range |
+|-------|------|---------|-------|
+| Retry Mode | Select | None | None, Fixed Interval, Exponential Backoff |
+| Initial Retry Delay (seconds) | Integer | 5 | 1–600 |
+| Retry Delay Jitter (seconds) | Integer | 2 | 0–120 |
+| Retry Count | Integer | 3 | 1–10 |
+
+## How nCino Calculates Retry Delay 
+
+**Fixed Interval:**
+
+```
+delay = retry_delay_seconds + random(0, retry_delay_jitter)
+```
+
+**Exponential Backoff:**
+
+```
+delay = (retry_delay_seconds × 2^attempt) + random(0, retry_delay_jitter)
+```
+
+Where `attempt` starts at 0 for the first retry.
+
+**Example:** With a 5-second base delay, 2-second jitter, and Exponential Backoff:
+
+| Attempt | Base Delay | Possible Total (with jitter) |
+|---------|-----------|------------------------------|
+| 1st retry | 5s (5 × 2⁰) | 5–7s |
+| 2nd retry | 10s (5 × 2¹) | 10–12s |
+| 3rd retry | 20s (5 × 2²) | 20–22s |
+
+## Viewing Retry History
+
+Each retry attempt creates its own entry in the Run History. Retry runs are labeled with `retry_for_run_id:<original_id>`, which links them back to the original failed run.
+
+The `retry_attempt` variable is available in integration hooks, which allows hook logic to behave differently based on the current attempt number.
+
+## Limits
+
+The maximum effective retry delay cannot exceed 5 minutes (300 seconds). For Exponential Backoff mode, the system validates that the longest possible delay (on the final retry attempt plus jitter) stays within this limit.

--- a/how-to-guides/how-to-track-mapping-progress.md
+++ b/how-to-guides/how-to-track-mapping-progress.md
@@ -18,7 +18,7 @@ To review mapping progress for an integration:
 
 The four forecast cards display these metrics:
 
-- **Project Status** — Whether the integration is on track, ahead of schedule, behind schedule, or past due. The system calculates this from the target date and the configured fields-per-day rate. If you do not set a target date, the status displays as "In Progress."
+- **Project Status** — Whether the integration is on track, ahead of schedule, behind schedule, or past due. The system calculates this from the target date and the configured fields-per-day rate, which only counts weekdays (Monday through Friday). If you do not set a target date, the status displays as "In Progress."
 - **Target Date** — The date the integration should reach completion. If the project is behind schedule, a "Need X/day" indicator shows the daily throughput required to finish on time.
 - **Fields / Day** — The configured daily mapping rate used for forecast calculations.
 - **Fields Left** — How many fields remain out of the total.

--- a/integration-gateway-platform-reference/integration-gateway-release-notes.md
+++ b/integration-gateway-platform-reference/integration-gateway-release-notes.md
@@ -2,6 +2,26 @@
 
 This page tracks features, bug fixes, and other improvements included in each Integration Gateway release.
 
+## v4.20.0 — June 2026
+
+### New Features
+
+* **Integration Retry**: Launched configurable Integration Retry, which supports both exponential back-off and fixed interval retry schedules
+* **SDLC Environment Banner**: Added SDLC environment banner to the IG UI in production environments
+
+### Improvements
+
+* **JXChange OAuth 2.0**: Updated JXChange SOAP adapter to use OAuth 2.0 authentication
+* **JXChange WSDL**: Added new WSDL version support for the jXchange adapter
+* **Custom Scheduler**: Replaced Celery with a custom scheduler for improved scheduling reliability
+* **Django 5.2**: Upgraded Django framework to v5.2
+* **Mapping Dashboard**: Improved calculation of Project Status and Fields per Day in the Mapping Dashboard
+
+### Bug Fixes
+
+* Resolved issue where ETL workflow failure emails did not send during validation failures
+* Fixed improper formatting in the View Changes diff display
+
 ## v4.19.0 — May 2026
 
 ### New Features

--- a/reference/integration_components/integration-config.md
+++ b/reference/integration_components/integration-config.md
@@ -60,6 +60,30 @@ Enables persistence of run history payloads for Integration Run Steps. The [#sto
 
 Number of days to persist Integration Run History Items. After this date run history payloads are deleted permanently. Defaults to 14 days.
 
+### retry\_mode
+
+<mark style="color:yellow;">`string`</mark> - <mark style="color:red;">`required`</mark>
+
+The retry strategy for failed integration runs. Options: `none` (default), `fixed` (Fixed Interval), `exponential` (Exponential Backoff). See [How to Configure Integration Retry](../../how-to-guides/how-to-configure-integration-retry.md) for details.
+
+### retry\_delay\_seconds
+
+<mark style="color:yellow;">`integer`</mark> - <mark style="color:red;">`required`</mark>
+
+The initial delay in seconds before retrying a failed run. Range: 1–600. Default: 5.
+
+### retry\_delay\_jitter
+
+<mark style="color:yellow;">`integer`</mark> - <mark style="color:red;">`required`</mark>
+
+Randomness in seconds added to each retry delay to prevent thundering herd problems. Range: 0–120. Default: 2.
+
+### max\_retries
+
+<mark style="color:yellow;">`integer`</mark> - <mark style="color:red;">`required`</mark>
+
+Maximum number of retry attempts for a failed run. Range: 1–10. Default: 3.
+
 ### engine\_version
 
 Engine version used when running this integration.


### PR DESCRIPTION
## Summary
- Added v4.20.0 release notes (date TBD — "June 2026" placeholder)
- Added "How to Configure Integration Retry" how-to guide (CP-1270)
- Updated Mapping Dashboard page with weekday-only clarification (CP-2828)
- Added retry fields to Integration Config reference page
- Updated SUMMARY.md TOC

## Notes for Thomas
- **Release date**: Placeholder "June 2026" — will update with exact date once confirmed
- **Integration Retry how-to**: Navigation steps based on PR #1887 code (right-click → Configure → Retry Settings panel). Needs verification once 4.20 deploys to dev (June 23-25)
- **Mapping Dashboard**: Single phrase added per your guidance ("only counts weekdays")

## Test plan
- [ ] Verify Retry Settings panel appears in Configure Integration dialog after 4.20 dev deploy
- [ ] Confirm release date and update release notes heading
- [ ] Review release note line items match final shipped features

🤖 Generated with [Claude Code](https://claude.com/claude-code)